### PR TITLE
Implement CI/CD Pipeline with Tag-Based Semantic Versioning

### DIFF
--- a/.github/workflows/docker-image-build-pipeline.yml
+++ b/.github/workflows/docker-image-build-pipeline.yml
@@ -1,29 +1,31 @@
 name: Build and push  Docker Image
 
-on: 
+on:
   push:
-    branches: 
-      - main
-  pull_request: 
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 
 jobs:
-  build: 
+  build:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Log in to Github Container Registry
+      - name: Extract Version from Tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
-        with: 
-          registry: ghrc.io
+        with:
+          registry: ghcr.io
           username: ${{ secrets.GITHUB_ACTOR }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Docker Image
-        run: docker build --no-cache -t ghcr.io/${{ github.repository }}/my-nginx:latest .
+        run: docker build --no-cache -t ghcr.io/${{ github.repository }}/my-nginx:$VERSION .
 
       - name: Push Docker Image to GHCR
-        run: docker push ghcr.io/${{ github.repository }}/my-nginx:latest
+        run: docker push ghcr.io/${{ github.repository }}/my-nginx:$VERSION
 


### PR DESCRIPTION
This PR introduces a GitHub Actions CI/CD pipeline that builds, and pushes a Docker image to GitHub Container Registry (GHCR). The pipeline is now optimised for semantic versioning, ensuring images are only built when a new annotated tag is pushed.