### PR TITLE
Add Automated Testing for Docker Image Before Push

### DIFF
--- a/.github/workflows/docker-image-build-pipeline.yml
+++ b/.github/workflows/docker-image-build-pipeline.yml
@@ -33,6 +33,27 @@ jobs:
       - name: Build Docker Image
         run: docker build --no-cache -t ghcr.io/$REPO_NAME/my-nginx:$VERSION .
 
+      - name: Test Docker Image
+        run: |
+          docker run -d --rm -p 8080:80 --name test-nginx ghcr.io/$REPO_NAME/my-nginx:$VERSION
+          
+          sleep 5
+          
+          if ! docker ps | grep -q test-nginx; then
+            echo "Test failed: Container did not start!"
+            exit 1
+          fi
+          
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
+          if [ "$RESPONSE" -ne 200 ]; then
+            echo "Test failed: Nginx did not serve the expected response!"
+            exit 1
+          fi
+          
+          echo "Test passed: Nginx is running and serving index.html correctly."
+          
+          docker stop test-nginx
+
       - name: Push Docker Image to GHCR
         run: docker push ghcr.io/$REPO_NAME/my-nginx:$VERSION
 


### PR DESCRIPTION
This PR adds an automated test step to verify that the Nginx container works before pushing it to GHCR.
The test ensures that:

1.     The container starts correctly.
2.     Nginx serves index.html as expected.
3.     The response returns HTTP 200.


If the test fails, the pipeline stops before pushing a broken image.