### PR TITLE
Fix repository references after renaming to lowercase

### DIFF
--- a/.github/workflows/docker-image-build-pipeline.yml
+++ b/.github/workflows/docker-image-build-pipeline.yml
@@ -20,9 +20,6 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-      - name: Convert Repository Name to Lowercase
-        run: echo "REPO_NAME=$(echo '${{ github.repository }}/my-nginx' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -31,11 +28,11 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Build Docker Image
-        run: docker build --no-cache -t ghcr.io/$REPO_NAME/my-nginx:$VERSION .
+        run: docker build --no-cache -t ghcr.io/joyjohansson/ci-cd-docker-kubernetes-ansible/my-nginx:$VERSION .
 
       - name: Test Docker Image
         run: |
-          docker run -d --rm -p 8080:80 --name test-nginx ghcr.io/$REPO_NAME/my-nginx:$VERSION
+          docker run -d --rm -p 8080:80 --name test-nginx ghcr.io/joyjohansson/ci-cd-docker-kubernetes-ansible/my-nginx:$VERSION
           
           sleep 5
           
@@ -55,5 +52,5 @@ jobs:
           docker stop test-nginx
 
       - name: Push Docker Image to GHCR
-        run: docker push ghcr.io/$REPO_NAME/my-nginx:$VERSION
+        run: docker push ghcr.io/joyjohansson/ci-cd-docker-kubernetes-ansible/my-nginx:$VERSION
 


### PR DESCRIPTION
- Updated GitHub Actions workflow to use the correct lowercase repository name.
- Fixed Docker image naming issues.
- Verified that all repository references are lowercase.

Reason: Some services, such as Docker, GHCR (GitHub Container Registry), and Kubernetes, require repository and image names to be lowercase due to compatibility and standardization rules.